### PR TITLE
convert --coverage to integer to avoid issues on Seqera Cloud

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -19,7 +19,7 @@ nextflow.enable.dsl = 2
 WorkflowMain.initialise(workflow, params, log)
 
 //Check coverage is above its threshold
-if (params.coverage < 30) { exit 1, 'The minimum coverage allowed for QA/QC purposes is 30 and is the default. Please choose a value >=30.' }
+if (params.coverage.toInteger() < 30) { exit 1, 'The minimum coverage allowed for QA/QC purposes is 30 and is the default. Please choose a value >=30.' }
 //Check path of kraken2db
 if (params.kraken2db == null) { exit 1, 'Input path to kraken2db not specified!' }
 


### PR DESCRIPTION
Minor change to address issue faced when running PHoeNIx on Seqera Cloud. Seqera Cloud seems to change the `--coverage` parameter value to a string, regardless of if you supply it as an integer in the config file. I was not able to replicate this on command line, but I have confirmed that this simple change fixes the problem on Seqera Cloud.