### PR TITLE
V2.2.1 hotfix

### DIFF
--- a/bin/local_MLST_converter.py
+++ b/bin/local_MLST_converter.py
@@ -960,6 +960,7 @@ def convert(to_convert):
         'Rhodococcus spp.' : 'rhodococcus',
         'Salmonella spp.' : 'salmonella_Achtman,salmonella_Oxford',
         'Saprolegnia parasitica' : 'sparasitica',
+        'Serratia spp.' : 'serratia',
         'Shewanella spp.' : 'shewanella',
         'Sinorhizobium spp.' : 'sinorhizobium',
         'Staphylococcus aureus' : 'saureus',

--- a/modules/local/mlst.nf
+++ b/modules/local/mlst.nf
@@ -222,7 +222,7 @@ process MLST {
     elif [[ \${genus,,} == "enterobacter" ]]; then
         if [[ \$scheme == "cronobacter" ]]; then
             mv ${prefix}.tsv ${prefix}.OLD-tsv
-            mlst --scheme ecloacae --threads $task.cpus \$unzipped_fasta > ${prefix}.tsv
+            mlst --scheme enterobacter --threads $task.cpus \$unzipped_fasta > ${prefix}.tsv
         fi
     else
         :


### PR DESCRIPTION
Hotfix to V2.2.1 due to 2 MLST issues discovered after release. 1 that completely breaks the pipeline when that taxonomy is found, Enterobacter, and 1 that just wont do MLST, Serratia. Both are corrected now.