### PR TITLE
MLST fix for Shigella

### DIFF
--- a/modules/local/mlst.nf
+++ b/modules/local/mlst.nf
@@ -199,7 +199,7 @@ process MLST {
     fi
 
     # New as of MLST 2.23.0, correctness score update results in some other species outperforming instrinsic ecoli_2 alleles in some cases. Force ecoli to run if ANI taxonomy says so
-    if [[ \${genus,,} == "escherichia" ]]; then
+    if [[ \${genus,,} == "escherichia" || \${genus,,} == "shigella" ]]; then
         if [[ \$scheme == "aeromonas" ]]; then
             mv ${prefix}.tsv ${prefix}.OLD-tsv
             mlst --scheme ecoli --threads $task.cpus \$unzipped_fasta > ${prefix}_1.tsv

--- a/nextflow_nftower_schema.json
+++ b/nextflow_nftower_schema.json
@@ -39,7 +39,7 @@
                 "input_sra": {
                     "type": "string",
                     "description": "Path to a csv file that has one SRR number per line.",
-                    "default": "null",
+                    "default": null,
                     "fa_icon": "fas fa-folder-open"
                 }
             }

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -66,7 +66,7 @@
                 "input_sra": {
                     "type": "string",
                     "description": "Path to a csv file that has one SRR number per line.",
-                    "default": "null",
+                    "default": null,
                     "fa_icon": "fas fa-folder-open"
                 },
                 "use_sra": {


### PR DESCRIPTION
*Recreation of PR Mlst fix 2.2.1 #205, but PR-ed to v2.3.0-dev


Correction of MLST determination for Ecoli when MLST scores of Ecoli are equal to those of other species is now also applied to when the genus is Shigella
Default value of input_sra changed from "null" to null as Seqera interprets "null" as string input for input_sra. I tested running this by terminal as well - null instead of "null" for input_sra was accepted both by when running Nextflow locally and in Seqera